### PR TITLE
Fix comment for local function candidates

### DIFF
--- a/src/IntercepTest/IntercepTestMockAttributeSyntaxReceiver.cs
+++ b/src/IntercepTest/IntercepTestMockAttributeSyntaxReceiver.cs
@@ -34,7 +34,7 @@ public class IntercepTestMockAttributeSyntaxReceiver : ISyntaxReceiver
     public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
     {
 
-        // any method with at least one attribute is a candidate for property generation
+        // any local function with at least one attribute is a candidate for method generation
         if (syntaxNode is LocalFunctionStatementSyntax localFunctionStatementSyntax)            
         {
             if (localFunctionStatementSyntax.AttributeLists.Select(al => al.Attributes.FirstOrDefault(a => ((IdentifierNameSyntax)a.Name).Identifier.ValueText == "IntercepTestMockAttribute" || ((IdentifierNameSyntax)a.Name).Identifier.ValueText == "IntercepTestMock")).FirstOrDefault() != null)


### PR DESCRIPTION
## Summary
- update the comment describing `LocalFunctionStatementSyntax` checks

## Testing
- `dotnet build IntercepTest.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686a5adef39c83218106b37cf09ec19c